### PR TITLE
アドバタイズパケット取得時にクラッシュするのを修正

### DIFF
--- a/adv.go
+++ b/adv.go
@@ -77,8 +77,13 @@ type Advertisement struct {
 }
 
 // This is only used in Linux port.
-func (a *Advertisement) unmarshall(b []byte) error {
-
+func (a *Advertisement) unmarshall(b []byte) (outErr error) {
+	var err error
+	defer func() {
+		if err := recover(); err != nil {
+			outErr = err.(error)
+		}
+	}()
 	// Utility function for creating a list of uuids.
 	uuidList := func(u []UUID, d []byte, w int) []UUID {
 		for len(d) > 0 {
@@ -135,7 +140,7 @@ func (a *Advertisement) unmarshall(b []byte) error {
 		}
 		b = b[1+l:]
 	}
-	return nil
+	return err
 }
 
 // AdvPacket is an utility to help crafting advertisment or scan response data.

--- a/central_darwin.go
+++ b/central_darwin.go
@@ -3,7 +3,7 @@ package gatt
 import (
 	"sync"
 
-	"github.com/paypal/gatt/xpc"
+	"github.com/aJunKobayashi/gatt/xpc"
 )
 
 type central struct {

--- a/device_darwin.go
+++ b/device_darwin.go
@@ -9,7 +9,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/paypal/gatt/xpc"
+	"github.com/aJunKobayashi/gatt/xpc"
 )
 
 const (

--- a/device_linux.go
+++ b/device_linux.go
@@ -4,8 +4,8 @@ import (
 	"encoding/binary"
 	"net"
 
-	"github.com/paypal/gatt/linux"
-	"github.com/paypal/gatt/linux/cmd"
+	"github.com/aJunKobayashi/gatt/linux"
+	"github.com/aJunKobayashi/gatt/linux/cmd"
 )
 
 type device struct {

--- a/examples/discoverer.go
+++ b/examples/discoverer.go
@@ -6,8 +6,8 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/paypal/gatt"
-	"github.com/paypal/gatt/examples/option"
+	"github.com/aJunKobayashi/gatt"
+	"github.com/aJunKobayashi/gatt/examples/option"
 )
 
 func onStateChanged(d gatt.Device, s gatt.State) {

--- a/examples/explorer.go
+++ b/examples/explorer.go
@@ -10,8 +10,8 @@ import (
 	"strings"
 	"time"
 
-	"github.com/paypal/gatt"
-	"github.com/paypal/gatt/examples/option"
+	"github.com/aJunKobayashi/gatt"
+	"github.com/aJunKobayashi/gatt/examples/option"
 )
 
 var done = make(chan struct{})

--- a/examples/option/option_darwin.go
+++ b/examples/option/option_darwin.go
@@ -1,6 +1,6 @@
 package option
 
-import "github.com/paypal/gatt"
+import "github.com/aJunKobayashi/gatt"
 
 var DefaultClientOptions = []gatt.Option{
 	gatt.MacDeviceRole(gatt.CentralManager),

--- a/examples/option/option_linux.go
+++ b/examples/option/option_linux.go
@@ -1,8 +1,8 @@
 package option
 
 import (
-	"github.com/paypal/gatt"
-	"github.com/paypal/gatt/linux/cmd"
+	"github.com/aJunKobayashi/gatt"
+	"github.com/aJunKobayashi/gatt/linux/cmd"
 )
 
 var DefaultClientOptions = []gatt.Option{

--- a/examples/server.go
+++ b/examples/server.go
@@ -6,9 +6,9 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/paypal/gatt"
-	"github.com/paypal/gatt/examples/option"
-	"github.com/paypal/gatt/examples/service"
+	"github.com/aJunKobayashi/gatt"
+	"github.com/aJunKobayashi/gatt/examples/option"
+	"github.com/aJunKobayashi/gatt/examples/service"
 )
 
 func main() {

--- a/examples/server_lnx.go
+++ b/examples/server_lnx.go
@@ -9,9 +9,9 @@ import (
 	"log"
 	"time"
 
-	"github.com/paypal/gatt"
-	"github.com/paypal/gatt/examples/service"
-	"github.com/paypal/gatt/linux/cmd"
+	"github.com/aJunKobayashi/gatt"
+	"github.com/aJunKobayashi/gatt/examples/service"
+	"github.com/aJunKobayashi/gatt/linux/cmd"
 )
 
 // server_lnx implements a GATT server.

--- a/examples/service/battery.go
+++ b/examples/service/battery.go
@@ -1,6 +1,6 @@
 package service
 
-import "github.com/paypal/gatt"
+import "github.com/aJunKobayashi/gatt"
 
 func NewBatteryService() *gatt.Service {
 	lv := byte(100)

--- a/examples/service/count.go
+++ b/examples/service/count.go
@@ -5,7 +5,7 @@ import (
 	"log"
 	"time"
 
-	"github.com/paypal/gatt"
+	"github.com/aJunKobayashi/gatt"
 )
 
 func NewCountService() *gatt.Service {

--- a/examples/service/gap.go
+++ b/examples/service/gap.go
@@ -1,6 +1,6 @@
 package service
 
-import "github.com/paypal/gatt"
+import "github.com/aJunKobayashi/gatt"
 
 var (
 	attrGAPUUID = gatt.UUID16(0x1800)

--- a/examples/service/gatt.go
+++ b/examples/service/gatt.go
@@ -3,7 +3,7 @@ package service
 import (
 	"log"
 
-	"github.com/paypal/gatt"
+	"github.com/aJunKobayashi/gatt"
 )
 
 var (

--- a/linux/cmd/cmd.go
+++ b/linux/cmd/cmd.go
@@ -7,8 +7,8 @@ import (
 	"io"
 	"log"
 
-	"github.com/paypal/gatt/linux/evt"
-	"github.com/paypal/gatt/linux/util"
+	"github.com/aJunKobayashi/gatt/linux/evt"
+	"github.com/aJunKobayashi/gatt/linux/util"
 )
 
 type CmdParam interface {

--- a/linux/device.go
+++ b/linux/device.go
@@ -7,8 +7,8 @@ import (
 	"syscall"
 	"unsafe"
 
-	"github.com/paypal/gatt/linux/gioctl"
-	"github.com/paypal/gatt/linux/socket"
+	"github.com/aJunKobayashi/gatt/linux/gioctl"
+	"github.com/aJunKobayashi/gatt/linux/socket"
 )
 
 type device struct {

--- a/linux/devices.go
+++ b/linux/devices.go
@@ -1,6 +1,6 @@
 package linux
 
-import "github.com/paypal/gatt/linux/gioctl"
+import "github.com/aJunKobayashi/gatt/linux/gioctl"
 
 const (
 	ioctlSize     = uintptr(4)

--- a/linux/evt/evt.go
+++ b/linux/evt/evt.go
@@ -5,7 +5,7 @@ import (
 	"encoding/binary"
 	"errors"
 
-	"github.com/paypal/gatt/linux/util"
+	"github.com/aJunKobayashi/gatt/linux/util"
 )
 
 type EventHandler interface {

--- a/linux/hci.go
+++ b/linux/hci.go
@@ -6,8 +6,8 @@ import (
 	"log"
 	"sync"
 
-	"github.com/paypal/gatt/linux/cmd"
-	"github.com/paypal/gatt/linux/evt"
+	"github.com/aJunKobayashi/gatt/linux/cmd"
+	"github.com/aJunKobayashi/gatt/linux/evt"
 )
 
 type HCI struct {

--- a/linux/l2cap.go
+++ b/linux/l2cap.go
@@ -5,7 +5,7 @@ import (
 	"io"
 	"log"
 
-	"github.com/paypal/gatt/linux/cmd"
+	"github.com/aJunKobayashi/gatt/linux/cmd"
 )
 
 type aclData struct {

--- a/option_linux.go
+++ b/option_linux.go
@@ -4,7 +4,7 @@ import (
 	"errors"
 	"io"
 
-	"github.com/paypal/gatt/linux/cmd"
+	"github.com/aJunKobayashi/gatt/linux/cmd"
 )
 
 // LnxDeviceID specifies which HCI device to use.

--- a/option_linux_test.go
+++ b/option_linux_test.go
@@ -3,7 +3,7 @@ package gatt
 import (
 	"bytes"
 
-	"github.com/paypal/gatt/linux/cmd"
+	"github.com/aJunKobayashi/gatt/linux/cmd"
 )
 
 func ExampleLnxDeviceID() {

--- a/peripheral_darwin.go
+++ b/peripheral_darwin.go
@@ -4,7 +4,7 @@ import (
 	"errors"
 	"log"
 
-	"github.com/paypal/gatt/xpc"
+	"github.com/aJunKobayashi/gatt/xpc"
 )
 
 type peripheral struct {

--- a/peripheral_linux.go
+++ b/peripheral_linux.go
@@ -10,7 +10,7 @@ import (
 	"net"
 	"strings"
 
-	"github.com/paypal/gatt/linux"
+	"github.com/aJunKobayashi/gatt/linux"
 )
 
 type peripheral struct {


### PR DESCRIPTION
func (a *Advertisement) unmarshall(b []byte) (outErr error)

で不正な配列にアクセスしてクラッシュすることがあるので修正