### PR TITLE
Go Routineがleakするのを修正

### DIFF
--- a/linux/l2cap.go
+++ b/linux/l2cap.go
@@ -87,6 +87,7 @@ func (c *conn) write(cid int, b []byte) (int, error) {
 
 		// make sure we don't send more buffers than the controller can handdle
 		c.hci.bufCnt <- struct{}{}
+		c.hci.pendingCommandNum[c.attr]++
 
 		c.hci.d.Write(w[:5+dlen])
 		w = w[dlen:] // advance the pointer to the next segment, if any.

--- a/peripheral_linux.go
+++ b/peripheral_linux.go
@@ -2,6 +2,7 @@ package gatt
 
 import (
 	"bytes"
+	"context"
 	"encoding/binary"
 	"errors"
 	"fmt"
@@ -410,6 +411,8 @@ func (p *peripheral) sendReq(op byte, b []byte) (data []byte, err error) {
 func (p *peripheral) loop() {
 	// Serialize the request.
 	rspc := make(chan []byte)
+	ctx := context.Background()
+	innerCtx, cancel := context.WithCancel(ctx)
 
 	var req message
 	// Dequeue request loop
@@ -421,7 +424,15 @@ func (p *peripheral) loop() {
 				if req.rspc == nil {
 					break
 				}
-				r := <-rspc
+				var r []byte
+				select {
+				case r = <-rspc:
+					break
+				case <-innerCtx.Done():
+					log.Printf("[loop] canceled")
+					return
+				}
+
 				switch reqOp, rspOp := req.b[0], r[0]; {
 				case rspOp == attRspFor[reqOp]:
 				case rspOp == attOpError && r[1] == reqOp:
@@ -430,6 +441,9 @@ func (p *peripheral) loop() {
 					// FIXME: terminate the connection?
 				}
 				req.rspc <- r
+			case <-innerCtx.Done():
+				log.Printf("[loop] canceled")
+				return
 			case <-p.quitc:
 				return
 			}
@@ -446,6 +460,7 @@ func (p *peripheral) loop() {
 		if n == 0 || err != nil {
 			close(p.quitc)
 			close(req.rspc)
+			cancel()
 			return
 		}
 


### PR DESCRIPTION
Go Routineがleakするのを修正

コマンドをHCIに要求し、エラー切断された場合
NumberOfCompletedPacketが通知されず、
hci.go のbufCntがデクリメントされず、チャンネルの書き込みでブロックする問題を修正