### PR TITLE
Fix crash in map

### DIFF
--- a/linux/hci.go
+++ b/linux/hci.go
@@ -301,7 +301,7 @@ func (h *HCI) handleNumberOfCompletedPkts(b []byte) error {
 				fmt.Printf("[handleNumberOfCompletedPkts] invalid peindingCommandNum: %+v", h.pendingCommandNum)
 				h.pendingCommandNum[connectionHandle] = 0
 			} else {
-				h.pendingCommandNum[connectionHandle]--
+				h.pendingCommandNum[connectionHandle] -= int(r.NumOfCompletedPkts)
 			}
 		}
 		for i := 0; i < int(r.NumOfCompletedPkts); i++ {

--- a/linux/l2cap.go
+++ b/linux/l2cap.go
@@ -87,7 +87,9 @@ func (c *conn) write(cid int, b []byte) (int, error) {
 
 		// make sure we don't send more buffers than the controller can handdle
 		c.hci.bufCnt <- struct{}{}
+		c.hci.mapmu.Lock()
 		c.hci.pendingCommandNum[c.attr]++
+		c.hci.mapmu.Unlock()
 
 		c.hci.d.Write(w[:5+dlen])
 		w = w[dlen:] // advance the pointer to the next segment, if any.


### PR DESCRIPTION
map内の数を正しく減算できていなかったのを修正
mapはスレッドセーフではないため、参照する前にロックする