### PR TITLE
remove needless error check.

### DIFF
--- a/linux/hci.go
+++ b/linux/hci.go
@@ -131,10 +131,7 @@ func (h *HCI) SetScanEnable(en bool, dup bool) error {
 }
 
 func (h *HCI) Connect(pd *PlatData) error {
-	err := h.setAdvertiseEnable(false)
-	if err != nil {
-		return err
-	}
+	h.setAdvertiseEnable(false)
 	h.c.Send(
 		cmd.LECreateConn{
 			LEScanInterval:        0x0004,         // N x 0.625ms


### PR DESCRIPTION
不要なエラーチェックを削除
失敗しても接続ができるためconnectをそのままするようにした。